### PR TITLE
Use aws credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.o
 *.a
 mkmf.log
+
+/vendor/bundle/

--- a/bin/s3-migrator
+++ b/bin/s3-migrator
@@ -10,6 +10,7 @@ OptionParser.new { |o|
   o.on("-s", "--src-bucket SOURCE_BUCKET") { |v| opts[:src_bucket] = v }
   o.on("-d", "--dest-bucket DESTINATION_BUCKET", ) { |v| opts[:dest_bucket] = v }
   o.on("-p", "--prefix [PREFIX]") { |v| opts[:prefix] = v }
+  o.on("--profile [AWS PROFILE]") { |v| opts[:profile] = v }
   o.on("-t", "--thread [COUNT]") { |v| opts[:thread_count] = v }
 }.parse!(ARGV)
 

--- a/lib/s3/migrator.rb
+++ b/lib/s3/migrator.rb
@@ -34,7 +34,7 @@ module S3
       logger = Logger.new(STDOUT)
 
       begin
-        each_in_threads(opts[:thread_count] || DEFAULT_THREAD_COUNT, pagerble.contents) do |obj|
+        each_in_threads(opts[:thread_count].to_i || DEFAULT_THREAD_COUNT, pagerble.contents) do |obj|
           begin
             s3_client.copy_object(
               bucket: opts[:dest_bucket],

--- a/lib/s3/migrator.rb
+++ b/lib/s3/migrator.rb
@@ -13,8 +13,17 @@ module S3
     DEFAULT_THREAD_COUNT = 10
 
     def migrate!(opts)
-      creds = Aws::Credentials.new(opts[:access_key_id], opts[:secret_access_key])
-      s3_client = Aws::S3::Client.new(credentials: creds, region: opts[:region])
+      # use ~/.aws/credentials if without credentials opts
+      creds = if opts[:profile]
+        Aws::SharedCredentials.new(profile_name: opts[:profile])
+      elsif opts[:access_key_id] && opts[:secret_access_key]
+        Aws::Credentials.new(opts[:access_key_id], opts[:secret_access_key])
+      end
+
+      client_opts = { region: opts[:region] || ENV['AWS_REGION'] }
+      client_opts[:credentials] = creds if creds
+
+      s3_client = Aws::S3::Client.new(client_opts)
 
       pagerble = if opts[:prefix]
         s3_client.list_objects(bucket: opts[:src_bucket], prefix: opts[:prefix])


### PR DESCRIPTION
Migrator use, `~/.aws/credentials` default.
Use aws profiles with `--profile` option.
